### PR TITLE
chore(ci): rename Github Actions test workflow name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: test
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
PR의 CI를 진행할 때 workflow 이름을 찾을 수 없는 문제를 해결

## Changes
- [x] test workflow 이름을 test (pull_request)로 지정
