### PR TITLE
Refactor: Refresh Token Guard에서 RefreshTokenRepository 관련 코드 제거

### DIFF
--- a/src/common/guards/refresh-token.guard.ts
+++ b/src/common/guards/refresh-token.guard.ts
@@ -1,4 +1,3 @@
-import { RefreshTokenRepository } from '@app/auth/repository/refresh-token.repository';
 import { AuthService } from '@app/auth/service/auth.service';
 import {
   CanActivate,
@@ -15,10 +14,7 @@ import { Request } from 'express';
 
 @Injectable()
 export class RefreshTokenGuard implements CanActivate {
-  constructor(
-    private readonly authService: AuthService,
-    private readonly refreshTokenRepository: RefreshTokenRepository,
-  ) {}
+  constructor(private readonly authService: AuthService) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const req = context.switchToHttp().getRequest<Request>();
@@ -35,22 +31,6 @@ export class RefreshTokenGuard implements CanActivate {
       const { sub: userId, jti } = payload;
       if (!userId || !jti) {
         throw new UnauthorizedException('Invalid refresh token payload');
-      }
-
-      const record = await this.refreshTokenRepository.findById(jti);
-      if (!record) {
-        throw new UnauthorizedException('Refresh token not found');
-      }
-      if (record.revokedAt) {
-        throw new UnauthorizedException('Refresh token revoked');
-      }
-      if (record.expiresAt && record.expiresAt.getTime() <= Date.now()) {
-        throw new UnauthorizedException('Refresh token expired');
-      }
-
-      const ok = await this.authService.compare(token, record.tokenHash);
-      if (!ok) {
-        throw new UnauthorizedException('Refresh token hash mismatch');
       }
 
       req.user = { userId, jti, refreshToken: token };


### PR DESCRIPTION
## Summary

리프레시 토큰 가드에서 리프레시 토큰 저장소 관련 코드 제거


