### PR TITLE
refactor: TagService, TagRepository, ArticleToRepository에 명시적 반환 타입 지정

### DIFF
--- a/src/article/entity/article.entity.ts
+++ b/src/article/entity/article.entity.ts
@@ -1,4 +1,5 @@
-import { Tag, User } from '@prisma/client';
+import { Tag } from '@app/tag/entity/tag.entity';
+import { User } from '@prisma/client';
 
 export class Article {
   id: string;
@@ -10,9 +11,9 @@ export class Article {
   createdAt: Date;
   updatedAt: Date;
 
+  tags?: Tag[];
   // ! Entity는 Domain Layer로 절대 Infrastructure Layer에 의존하면 안됨
   // ! 지금은 초기 구현 & Article 관련 로직만을 리팩토링하고 있어서
   // ! Tag Domain, User Domain의 로직을 수정하지 않는 방안으로 Prisma Client가 제공하는 타입 임시로 사용
-  tags?: Tag[];
   auth?: User;
 }

--- a/src/articleToTag/articleToTag.repository.ts
+++ b/src/articleToTag/articleToTag.repository.ts
@@ -11,7 +11,7 @@ export class ArticleToTagRepository {
     articleId: string,
     tagList: Tag[],
     prisma: PrismaTransaction = this.prisma,
-  ) {
+  ): Promise<void> {
     await prisma.articleTag.createMany({
       data: tagList.map((tag) => ({
         articleId,

--- a/src/tag/entity/tag.entity.ts
+++ b/src/tag/entity/tag.entity.ts
@@ -1,0 +1,7 @@
+import { Article } from '@app/article/entity/article.entity';
+
+export class Tag {
+  id: string;
+  name: string;
+  post?: Article;
+}

--- a/src/tag/tag.repository.ts
+++ b/src/tag/tag.repository.ts
@@ -1,6 +1,7 @@
 import { PrismaService } from '@app/prisma/prisma.service';
 import { PrismaTransaction } from '@app/prisma/transaction.type';
 import { Injectable } from '@nestjs/common';
+import { Tag } from '@prisma/client';
 
 @Injectable()
 export class TagRepository {
@@ -19,7 +20,7 @@ export class TagRepository {
   async findTagListByTagNames(
     tagNames: string[],
     prisma: PrismaTransaction = this.prisma,
-  ) {
+  ): Promise<Tag[]> {
     return await prisma.tag.findMany({
       where: {
         name: {
@@ -32,7 +33,7 @@ export class TagRepository {
   async findTagListByIds(
     tagsId: string[],
     prisma: PrismaTransaction = this.prisma,
-  ) {
+  ): Promise<Tag[]> {
     return await prisma.tag.findMany({
       where: {
         id: {

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -15,7 +15,7 @@ export class TagService {
     return tagList.map((tag) => tag.toLowerCase());
   }
 
-  async getTagNames(articleToTag: IArticleToTag[]) {
+  async getTagNames(articleToTag: IArticleToTag[]): Promise<string[]> {
     const tagIds = articleToTag.map((recode) => recode.tagId);
     const tagList = await this.tagRepository.findTagListByIds(tagIds);
 


### PR DESCRIPTION
## Summary

- Tag Entity 생성
- TagSerivce의 반환 타입에 명시적 타입 지정,
- TagRepository에 Prisma Client가 제공하는 반환 타입 지정
- ArticleToTag의 반환 타입을 Promise<void>를 명시적으로 지정해서 return이 존재하지 않음을 인지시킴
